### PR TITLE
Dash Extension Fix

### DIFF
--- a/source/Dash/Config.plist
+++ b/source/Dash/Config.plist
@@ -9,8 +9,8 @@
 			<string>256-head.png</string>
 			<key>Regular Expression</key>
 			<string>(?s)^.{1,160}$</string>
-			<key>Service Name</key>
-			<string>Look up in Dash</string>
+			<key>URL</key>
+			<string>dash://{popclip text}</string>
 			<key>Title</key>
 			<string>Dash</string>
 		</dict>


### PR DESCRIPTION
I've changed the "Look up in Dash" service to "Look Up in Dash" in the latest Dash. I did not know that PopClip uses this service to call Dash, so this change has broken the PopClip extension. Do accept my apologies for this.

This pull request changes the extension to use the dash:// URL scheme, instead of the system service.
