### PR TITLE
Add shortly.pw to ShortenLink extension

### DIFF
--- a/source/ShortenLink/Config.plist
+++ b/source/ShortenLink/Config.plist
@@ -31,7 +31,7 @@
 		</dict>
 	</array>
 	<key>Extension Description</key>
-	<string>Turn a long URL into a much shorter one. Services available: goo.gl, is.gd, v.gd, short-url.</string>
+	<string>Turn a long URL into a much shorter one. Services available: goo.gl, is.gd, v.gd, shortly.pw.</string>
 	<key>Extension Identifier</key>
 	<string>com.pilotmoon.popclip.extension.urlshortener</string>
 	<key>Extension Name</key>
@@ -53,7 +53,7 @@
 				<string>goo.gl</string>
 				<string>is.gd</string>
 				<string>v.gd</string>
-				<string>short-url</string>
+				<string>shortly.pw</string>
 			</array>
 		</dict>
 	</array>

--- a/source/ShortenLink/urlshortener.py
+++ b/source/ShortenLink/urlshortener.py
@@ -16,7 +16,7 @@ api = {
 	'goo.gl' : 'https://www.googleapis.com/urlshortener/v1/url',
 	'is.gd' : 'http://is.gd/create.php?format=json&logstats=1&url=',  
 	'v.gd' : 'http://v.gd/create.php?format=json&logstats=1&url=',
-    'short-url' : 'http://short-url.herokuapp.com/api/shorten?url='
+    	'shortly.pw' : 'http://api.shortly.pw/api/shorten?url='
 #	'tiny.cc' : 'http://tiny.cc/?c=rest_api&m=shorten&version=2.0.3&format=json&shortUrl=&login=xxx&apiKey=yyy&longUrl='
 }
 
@@ -48,7 +48,7 @@ elif serviceDomain == 'is.gd':
     output = json.loads(getLink(service,url))["shorturl"]
 elif serviceDomain == 'v.gd':
     output = json.loads(getLink(service,url))["shorturl"]
-elif serviceDomain == 'short-url':
+elif serviceDomain == 'shortly.pw':
     output = json.loads(getLink(service,url))["short_url"]
 #elif serviceDomain == 'tiny.cc':
 #    output = json.loads(getLink(service,url))["results"]["short_url"]


### PR DESCRIPTION
shortly.pw is a new service (backed by Java and parse.com) to provide a shorten/unshorten URLs.

This pull request is to slightly modify the ShortenLink ext. to add `shortly.pw` to it.
