### PR TITLE
change instantTranslate to google's https server, http server is down

### DIFF
--- a/source/InstantTranslate/translate.py
+++ b/source/InstantTranslate/translate.py
@@ -55,9 +55,9 @@ class Translator:
         escaped_source = quote(source, '')
         headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19'}
         req = request.Request(
-             url="http://translate.google.com/translate_a/t?client=t&ie=UTF-8&oe=UTF-8"
-                 +"&sl=%s&tl=%s&text=%s" % (self.from_lang, self.to_lang, escaped_source)
-                 , headers = headers)
+            url="https://translate.google.com/translate_a/single?client=t&ie=UTF-8&oe=UTF-8&dt=t"
+                +"&sl=%s&tl=%s&q=%s" % (self.from_lang, self.to_lang, escaped_source)
+                , headers = headers)
         r = request.urlopen(req)
         return r.read().decode('utf-8')
 


### PR DESCRIPTION
cost down the size of json data

old json data:

```
Rex-mbp:InstantTranslate.popclipext rex$ python translate.py "hello world"
[[["你好世界","hello world","Nǐ hǎo shìjiè",""]],,"en",,[["你好",[34],false,false,912,0,1,1],["世界",[35],false,false,906,1,2,1]],[["hello",34,[["你好",912,false,false],["您好",21,false,false],["打招呼",0,false,false],["招呼",0,false,false],["问候",0,false,false]],[[0,5]],"hello world"],["world",35,[["世界",906,false,false],["全球",5,false,false],["全世界",0,false,false],["世界上",0,false,false],["的世界",0,false,false]],[[6,11]],""]],,,[["en"]],1]
```

new json data:

```
Rex-mbp:InstantTranslate.popclipext rex$ python translate.py "hello world"
[[["你好世界","hello world"]],,"en",,,,,,[["en"],,[0.085707255]]]
```
