### PR TITLE
Allow dashes inside tracking numbers

### DIFF
--- a/source/Deliveries/Config.plist
+++ b/source/Deliveries/Config.plist
@@ -12,7 +12,7 @@
 			<key>Title</key>
 			<string>Parcel</string>
 			<key>Regular Expression</key>
-			<string>(?i)\b(?=[A-Z0-9]*[0-9][A-Z0-9]*)[A-Z0-9]{5,}\b</string>
+			<string>(?i)\b(?=[A-Z0-9]?[A-Z0-9-]*[0-9][A-Z0-9-]*[A-Z0-9]?)[A-Z0-9-]{5,}\b</string>
 		</dict>
 	</array>
 	<key>Apps</key>


### PR DESCRIPTION
Deliveries supports Amazon order numbers for tracking, but the current regex doesn't match them because they contain dashes. This adds dash matching to the regex.
