### PR TITLE
Adding cryptographic hash extensions

### DIFF
--- a/source/MD5/Config.plist
+++ b/source/MD5/Config.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Actions</key>
+	<array>
+		<dict>
+			<key>After</key>
+			<string>paste-result</string>
+			<key>Shell Script File</key>
+			<string>md5.sh</string>
+			<key>Stoppable</key>
+			<true/>
+			<key>Title</key>
+			<string>MD5</string>
+		</dict>
+	</array>
+	<key>Credits</key>
+	<array>
+		<dict>
+			<key>Link</key>
+			<string>https://alenpuzic.com</string>
+			<key>Name</key>
+			<string>Alen Puzic</string>
+		</dict>
+	</array>
+	<key>Extension Name</key>
+    <string>MD5</string>
+	<key>Version</key>
+	<integer>1</integer>
+	<key>Extension Description</key>
+	<string>Produce a MD5 hash from the selected text.</string>
+	<key>Extension Identifier</key>
+	<string>com.alenpuzic.popclip.extension.md5</string>
+</dict>
+</plist>

--- a/source/MD5/README.md
+++ b/source/MD5/README.md
@@ -1,0 +1,9 @@
+MD5 PopClip Extension
+===
+
+PopClip extension that produces a MD5 hash from selected text.
+For more details about MD5 please visit [Wikipedia](http://en.wikipedia.org/wiki/MD5).
+
+Credits
+-------
+Written by [Alen Puzic](https://alenpuzic.com).

--- a/source/MD5/md5.sh
+++ b/source/MD5/md5.sh
@@ -1,0 +1,1 @@
+/bin/echo -n "$POPCLIP_TEXT" | /usr/bin/openssl dgst -md5

--- a/source/SHA-1/Config.plist
+++ b/source/SHA-1/Config.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Actions</key>
+	<array>
+		<dict>
+			<key>After</key>
+			<string>paste-result</string>
+			<key>Shell Script File</key>
+			<string>sha-1.sh</string>
+			<key>Stoppable</key>
+			<true/>
+			<key>Title</key>
+			<string>SHA-1</string>
+		</dict>
+	</array>
+	<key>Credits</key>
+	<array>
+		<dict>
+			<key>Link</key>
+			<string>https://alenpuzic.com</string>
+			<key>Name</key>
+			<string>Alen Puzic</string>
+		</dict>
+	</array>
+	<key>Extension Name</key>
+    <string>SHA-1</string>
+	<key>Version</key>
+	<integer>1</integer>
+	<key>Extension Description</key>
+	<string>Produce a SHA-1 hash from the selected text.</string>
+	<key>Extension Identifier</key>
+	<string>com.alenpuzic.popclip.extension.sha1</string>
+</dict>
+</plist>

--- a/source/SHA-1/README.md
+++ b/source/SHA-1/README.md
@@ -1,0 +1,9 @@
+SHA-1 PopClip Extension
+===
+
+PopClip extension that produces a SHA-1 hash from selected text.
+For more details about SHA-1 please visit [Wikipedia](http://en.wikipedia.org/wiki/SHA-1).
+
+Credits
+-------
+Written by [Alen Puzic](https://alenpuzic.com).

--- a/source/SHA-1/sha-1.sh
+++ b/source/SHA-1/sha-1.sh
@@ -1,0 +1,1 @@
+/bin/echo -n "$POPCLIP_TEXT" | /usr/bin/openssl dgst -sha1

--- a/source/SHA-256/Config.plist
+++ b/source/SHA-256/Config.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Actions</key>
+	<array>
+		<dict>
+			<key>After</key>
+			<string>paste-result</string>
+			<key>Shell Script File</key>
+			<string>sha-256.sh</string>
+			<key>Stoppable</key>
+			<true/>
+			<key>Title</key>
+			<string>SHA-256</string>
+		</dict>
+	</array>
+	<key>Credits</key>
+	<array>
+		<dict>
+			<key>Link</key>
+			<string>https://alenpuzic.com</string>
+			<key>Name</key>
+			<string>Alen Puzic</string>
+		</dict>
+	</array>
+	<key>Extension Name</key>
+    <string>SHA-256</string>
+	<key>Version</key>
+	<integer>1</integer>
+	<key>Extension Description</key>
+	<string>Produce a SHA-256 hash from the selected text.</string>
+	<key>Extension Identifier</key>
+	<string>com.alenpuzic.popclip.extension.sha256</string>
+</dict>
+</plist>

--- a/source/SHA-256/README.md
+++ b/source/SHA-256/README.md
@@ -1,0 +1,9 @@
+SHA-256 PopClip Extension
+===
+
+PopClip extension that produces a SHA-256 hash from selected text.
+For more details about SHA-256 please visit [Wikipedia](http://en.wikipedia.org/wiki/SHA-2).
+
+Credits
+-------
+Written by [Alen Puzic](https://alenpuzic.com).

--- a/source/SHA-256/sha-256.sh
+++ b/source/SHA-256/sha-256.sh
@@ -1,0 +1,1 @@
+/bin/echo -n "$POPCLIP_TEXT" | /usr/bin/openssl dgst -sha256

--- a/source/SHA-512/Config.plist
+++ b/source/SHA-512/Config.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Actions</key>
+	<array>
+		<dict>
+			<key>After</key>
+			<string>paste-result</string>
+			<key>Shell Script File</key>
+			<string>sha-512.sh</string>
+			<key>Stoppable</key>
+			<true/>
+			<key>Title</key>
+			<string>SHA-512</string>
+		</dict>
+	</array>
+	<key>Credits</key>
+	<array>
+		<dict>
+			<key>Link</key>
+			<string>https://alenpuzic.com</string>
+			<key>Name</key>
+			<string>Alen Puzic</string>
+		</dict>
+	</array>
+	<key>Extension Name</key>
+    <string>SHA-512</string>
+	<key>Version</key>
+	<integer>1</integer>
+	<key>Extension Description</key>
+	<string>Produce a SHA-512 hash from the selected text.</string>
+	<key>Extension Identifier</key>
+	<string>com.alenpuzic.popclip.extension.sha512</string>
+</dict>
+</plist>

--- a/source/SHA-512/README.md
+++ b/source/SHA-512/README.md
@@ -1,0 +1,9 @@
+SHA-512 PopClip Extension
+===
+
+PopClip extension that produces a SHA-512 hash from selected text.
+For more details about SHA-512 please visit [Wikipedia](http://en.wikipedia.org/wiki/SHA-2).
+
+Credits
+-------
+Written by [Alen Puzic](https://alenpuzic.com).

--- a/source/SHA-512/sha-512.sh
+++ b/source/SHA-512/sha-512.sh
@@ -1,0 +1,1 @@
+/bin/echo -n "$POPCLIP_TEXT" | /usr/bin/openssl dgst -sha512


### PR DESCRIPTION
Adding MD5/SHA1/SHA256/SHA512 cryptographic hash/digest PopClip extensions.

Signed-off-by: Alen Puzic <alen.puzic@gmail.com>