### PR TITLE
Adding a Whois extension.

### DIFF
--- a/source/WhoIs/Config.plist
+++ b/source/WhoIs/Config.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Actions</key>
+	<array>
+		<dict>
+			<key>URL</key>
+			<string>http://www.whois.com/whois/{popclip text}</string>
+			<key>Title</key>
+			<string>Whois</string>
+			<key>Regular Expression</key>
+			<string>(?s)^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}$</string>
+		</dict>
+	</array>
+	<key>Credits</key>
+	<array>
+		<dict>
+			<key>Link</key>
+			<string>https://alenpuzic.com</string>
+			<key>Name</key>
+			<string>Alen Puzic</string>
+		</dict>
+	</array>
+	<key>Extension Name</key>
+    <string>Whois</string>
+	<key>Version</key>
+	<integer>1</integer>
+	<key>Extension Description</key>
+	<string>Lookup Whois information for a selected domain name.</string>
+	<key>Extension Identifier</key>
+	<string>com.alenpuzic.popclip.extension.whois</string>
+</dict>
+</plist>

--- a/source/WhoIs/README.md
+++ b/source/WhoIs/README.md
@@ -1,0 +1,8 @@
+WhoIs PopClip Extension
+===
+
+PopClip extension that provides a shortcut for retrieving Whois information for a domain name.
+
+Credits
+-------
+Written by [Alen Puzic](https://alenpuzic.com).


### PR DESCRIPTION
Whois extension that uses whois.com as a data source, for now.

Signed-off-by: Alen Puzic alen.puzic@gmail.com
