### PR TITLE
Improve new line handling for SublimeText

### DIFF
--- a/source/SublimeText/Config.plist
+++ b/source/SublimeText/Config.plist
@@ -6,7 +6,9 @@
 	<array>
 		<dict>
 			<key>Image File</key>
-			<string></string>			
+			<string></string>
+			<key>Script Interpreter</key>
+			<string>/bin/bash</string>
 			<key>Shell Script File</key>
 			<string>sublime.sh</string>
 			<key>Title</key>

--- a/source/SublimeText/sublime.sh
+++ b/source/SublimeText/sublime.sh
@@ -1,1 +1,1 @@
-echo $POPCLIP_TEXT | open -f -a "Sublime Text"
+echo -n "$POPCLIP_TEXT" | open -f -a "Sublime Text"


### PR DESCRIPTION
Fixed new line character handling. Right now, the new line was converted to space.