### PR TITLE
Update Eudic extension to use applescript

### DIFF
--- a/source/Eudic/Config.plist
+++ b/source/Eudic/Config.plist
@@ -5,18 +5,39 @@
 	<key>Actions</key>
 	<array>
 		<dict>
+			<key>AppleScript File</key>
+			<string>eudic.applescript</string>
 			<key>Image File</key>
 			<string>eudic.png</string>
-			<key>Service Name</key>
-			<string>Eudic • 翻译选中内容</string>
 			<key>Title</key>
 			<string>Search In Eudic</string>
+		</dict>
+	</array>
+	<key>Options</key>
+	<array>
+		<dict>
+		    <key>Option Identifier</key>
+			<string>eudic_version</string>
+			<key>Option Label</key>
+			<dict>
+				<key>en</key>
+				<string>EuDic Version</string>
+			</dict>
+			<key>Option Type</key>
+			<string>multiple</string>
+			<key>Option Values</key>
+			<array>
+				<string>com.eusoft.freeeudic</string>
+				<string>com.eusoft.eudic</string>
+			</array>		
+			<key>Option Description</key>
+			<string></string>
 		</dict>
 	</array>
 	<key>Extension Description</key>
 	<string>Look up the selected text in Eudic, the Chinese-English dictionary.</string>
 	<key>Extension Identifier</key>
-	<string>com.pilotmoon.popclip.extension.eudic</string>
+	<string>com.pilotmoon1.popclip.extension.eudic</string>
 	<key>Extension Name</key>
 	<string>Eudic</string>
 	<key>Apps</key>

--- a/source/Eudic/eudic.applescript
+++ b/source/Eudic/eudic.applescript
@@ -1,0 +1,4 @@
+tell application id "{popclip option eudic_version}"
+	activate
+	show dic with word "{popclip text}"
+end tell


### PR DESCRIPTION
Eudic supports AppleScript since Version 3.6.3 and it's way more effective to use AppleScript than Service.

With EuDic service, its window always freezes for a few seconds, which is no longer a problem using AppleScript.