### PR TITLE
Make speaking lists better

### DIFF
--- a/source/Say/say.sh
+++ b/source/Say/say.sh
@@ -1,1 +1,2 @@
-echo $POPCLIP_TEXT | say
+result_string="${POPCLIP_TEXT//\*/+}"
+echo "$result_string" | say


### PR DESCRIPTION
Previously, when Say was used to read lists with stars "*" as list points, it spoke its directory contents. 
They're now being replaced with plus "+" to make clear that a new list point is starting. 
The plus sign works and is localised. "list dot" is long and would need localisation.