### PR TITLE
Fix: PopClip does not run command when there is no iTerm window

### DIFF
--- a/source/RunCommand/iterm2-3.applescript
+++ b/source/RunCommand/iterm2-3.applescript
@@ -1,6 +1,7 @@
 -- new version of script for iTerm2 v2.9+
 tell application id "com.googlecode.iterm2"
 	activate
+	create window with default profile
 	set _session to current session of current window
 	tell _session
 		set command to get the clipboard


### PR DESCRIPTION
If there is no iTerm window opening, before this fix there will be no
effect if people use PopClip. After this fix, the script will first create
a window before running the command. This may not be a perfect fix
but at least less annoying.