### PR TITLE
Add some markdown syntax into Quotes/Config.plist

### DIFF
--- a/source/Quotes/Config.plist
+++ b/source/Quotes/Config.plist
@@ -46,6 +46,13 @@
 				<string>『…』</string>
 				<string>„…“</string>
 				<string>‚…‘</string>
+				<string>`…`</string>
+				<string>*…*</string>
+				<string>**…**</string>
+				<string>~~…~~</string>
+				<string>~~…~~</string>
+				<string>++…++</string>
+				<string>==…==</string>
 			</array>
 		</dict>
 	</array>

--- a/source/Quotes/Config.plist
+++ b/source/Quotes/Config.plist
@@ -50,7 +50,6 @@
 				<string>*…*</string>
 				<string>**…**</string>
 				<string>~~…~~</string>
-				<string>~~…~~</string>
 				<string>++…++</string>
 				<string>==…==</string>
 			</array>


### PR DESCRIPTION
Add bold, italic, strikethrough, insert etc. syntax for markdown file

for example:

`*Italic*` -> *Italic*
`**Bold**` -> **Bold**
``` `Code` ``` -> `Code`
`~~Strikethrough~~` -> ~~Strikethrough~~
`++Underline++` -> ++Underline++   (github not support)
`==Text background color==` -> ==Text background color==  (github not support)