### PR TITLE
Add support for Setapp version of Dash

### DIFF
--- a/source/Dash/Config.plist
+++ b/source/Dash/Config.plist
@@ -23,6 +23,7 @@
 				<string>com.kapeli.dash</string>
 				<string>com.kapeli.dashdoc</string>
 				<string>com.kapeli.dashbeta</string>
+				<string>com.kapeli.dash-setapp</string>
 			</array>
             		<key>Check Installed</key>
 			<true/>


### PR DESCRIPTION
Dash is now available [via Setapp](https://setapp.com/apps/dash). This version has a new bundle identifier: `com.kapeli.dash-setapp`