### PR TITLE
Update Highlight to support Obsidian and Logseq

### DIFF
--- a/source/Highlight/Config.plist
+++ b/source/Highlight/Config.plist
@@ -20,6 +20,7 @@
 				<string>net.sourceforge.skim-app.skim</string>
 				<string>com.evernote.Evernote</string>
 				<string>com.readdle.PDFExpert-Mac</string>
+				<string>md.obsidian</string>
 			</array>
 			<key>Title</key>
 			<string>Highlight</string>
@@ -39,6 +40,7 @@
 				<string>com.literatureandlatte.scrivener2</string>
 				<string>com.literatureandlatte.scrivener3</string>
 				<string>com.apple.iWork.Pages</string>
+				<string>com.electron.logseq</string>
 			</array>
 			<key>Title</key>
 			<string>Highlight</string>

--- a/source/Highlight/README.md
+++ b/source/Highlight/README.md
@@ -7,17 +7,20 @@ This extension is a replacement for the PreviewHighlight extension. The intentio
 ## List of currently supported apps, by keyboard shortcut
 
 ### ⌃⌘H
-Preview
-PDF Expert
-Skim
-Evernote
+- Preview
+- PDF Expert
+- Skim
+- Evernote
+- Obsidian
 
 ### ⇧⌘H
-Pages
-Scrivener
+- Pages
+- Scrivener
+- Logseq
 
 ### ⇧⌘L
-Alternote
-DevonThink
+- Alternote
+- DevonThink
 
+8 Feb 2022: Added support for Obsidian and Logseq
 4 Jan 2018: Added support for Scrivener 3


### PR DESCRIPTION
Support the following apps

- [Logseq](https://logseq.com/)
- [Obsidian](https://obsidian.md/)

Note that Obsidian does not offer default *Hotkeys* for `Toggle highlight`. User should set that to <kbd>⌃⌘H</kbd>