### PR TITLE
Add a PT-BR dictionary

### DIFF
--- a/source/OnlineDictionary.popclipext/Config.js
+++ b/source/OnlineDictionary.popclipext/Config.js
@@ -1,4 +1,5 @@
 let services = {
+    'dicio.com.br': 'https://www.dicio.com.br/***',
     'dict.cc': 'https://www.dict.cc/?s=***',
     'dict.cn': 'https://dict.cn/***',
     'dict.leo.org': 'https://dict.leo.org/?search=***',


### PR DESCRIPTION
Dicio is an online dictionary widely used in Brazil and it would be very useful to be able to search directly from PopClip.