### PR TITLE
Add support languages in DeepL Translator. (Korean, Norwegian)

### DIFF
--- a/source/DeepLTranslator.popclipext/langs.json
+++ b/source/DeepLTranslator.popclipext/langs.json
@@ -77,6 +77,11 @@
             "supports_formality": false
         },
         {
+            "language": "KO",
+            "name": "Korean",
+            "supports_formality": false
+        },
+        {
             "language": "LT",
             "name": "Lithuanian",
             "supports_formality": false
@@ -84,6 +89,11 @@
         {
             "language": "LV",
             "name": "Latvian",
+            "supports_formality": false
+        },
+        {
+            "language": "NB",
+            "name": "Norwegian (Bokmål)",
             "supports_formality": false
         },
         {


### PR DESCRIPTION
A short PR for integrating DeepL translator services.
Added a list of languages supported as of 2023.4.7.