### PR TITLE
fixed `model` parameter defined but not used

### DIFF
--- a/source/ChatGPT.popclipext/chatgpt.js
+++ b/source/ChatGPT.popclipext/chatgpt.js
@@ -33,7 +33,7 @@ const chat = async (input, options) => {
     // send the whole message history to OpenAI
     try {
         const { data } = await openai.post("chat/completions", {
-            model: "gpt-3.5-turbo",
+            model: options.model || "gpt-3.5-turbo",
             messages,
         });
         // add the response to the history

--- a/source/ChatGPT.popclipext/chatgpt.ts
+++ b/source/ChatGPT.popclipext/chatgpt.ts
@@ -62,7 +62,7 @@ const chat: ActionFunction<ChatGPTOptions> = async (input, options) => {
     const { data }: Response = await openai.post(
       "chat/completions",
       {
-        model: "gpt-3.5-turbo",
+        model: options.model || "gpt-3.5-turbo",
         messages,
       },
     );


### PR DESCRIPTION
Hi Nick, I'm using the ChatGPT extension. I've checked the project configuration, but the model parameter doesn't appear in the code. This means that users will always be using gpt-3.5 even if they choose gpt4.