### PR TITLE
Add new Translatium bundle ID

### DIFF
--- a/source/Translatium.popclipext/Config.plist
+++ b/source/Translatium.popclipext/Config.plist
@@ -26,6 +26,7 @@
 		<dict>
 			<key>Bundle Identifiers</key>
 			<array>
+				<string>io.webcatalog.translatium</string>
 				<string>com.webcatalog.translatium</string>
 				<string>com.moderntranslator.app</string>
 			</array>


### PR DESCRIPTION
Translatium has been re-published with a new bundle ID: https://apps.apple.com/us/app/translatium-translator/id6473051769

This PR adds the new ID to the array.