### PR TITLE
Add GPT-4 Turbo model

### DIFF
--- a/source/ChatGPT.popclipext/Config.json
+++ b/source/ChatGPT.popclipext/Config.json
@@ -25,7 +25,7 @@
       "label": "Model",
       "type": "multiple",
       "defaultValue": "gpt-3.5-turbo",
-      "values": ["gpt-3.5-turbo", "gpt-4"]
+      "values": ["gpt-3.5-turbo", "gpt-4-turbo-preview", "gpt-4"]
     },
     {
       "identifier:": "resetMinutes",

--- a/source/ChatGPT.popclipext/Readme.md
+++ b/source/ChatGPT.popclipext/Readme.md
@@ -1,6 +1,6 @@
 # ChatGPT
 
-PopClip extension to send the selected text to [OpenAI](https://openai.com/)'s GPT-3.5 chat API, and append the response.
+PopClip extension to send the selected text to [OpenAI](https://openai.com/)'s GPT-3.5 and GPT-4 chat API, and append the response.
 
 **Note: Requires pre-paid API credits on your OpenAI account. API usage is not included in ChatGPT Plus subscripiton.**
 
@@ -36,7 +36,7 @@ account. To get an API Key:
 
 #### Model
 
-Available values are `gpt-3.5-turbo` and `gpt-4`. Note that some accounts might not be able to access the GPT-4 model — see OpenAI's documentation for details.
+Available values are `gpt-3.5-turbo`, `gpt-4-turbo-preview` and `gpt-4`. Note that some accounts might not be able to access the GPT-4 model — see OpenAI's documentation for details.
 
 #### Reset Timer (minutes)
 


### PR DESCRIPTION
Hi Nick, I'm using the ChatGPT extension and absolutely love it. I was wondering if we could add the GPT-4 Turbo model to the list of options. The model is 2-3 times cheaper, is the most updated and includes multiple fixes that the GPT-4 model is not getting.