### PR TITLE
Update Translatium bundle ID

### DIFF
--- a/source/Translatium.popclipext/Config.plist
+++ b/source/Translatium.popclipext/Config.plist
@@ -26,9 +26,7 @@
 		<dict>
 			<key>Bundle Identifiers</key>
 			<array>
-				<string>io.webcatalog.translatium</string>
-				<string>com.webcatalog.translatium</string>
-				<string>com.moderntranslator.app</string>
+				<string>com.translatium.app</string>
 			</array>
 			<key>Check Installed</key>
 			<true/>


### PR DESCRIPTION
Translatium has been re-published with a new bundle ID: https://apps.apple.com/us/app/translatium/id6541750489?mt=12&platform=mac

This PR adds the new ID and removes older bundle IDs (older versions have been deprecated) from the list.