### PR TITLE
fix: accurately determine unix time string

### DIFF
--- a/source/UnixTime.popclipext/Config.json
+++ b/source/UnixTime.popclipext/Config.json
@@ -1,5 +1,5 @@
 {
-	"regex": "\\d[ \\d]{3,15}\\d",
+	"regex": "^\\d[ \\d]{3,15}\\d$",
 	"description": "Convert Unix time (in seconds since 01-01-1970) to UTC.",
 	"identifier": "com.pilotmoon.popclip.extension.unix-time",
 	"name": "Unix Time",


### PR DESCRIPTION
Avoid content like `abc123456789abc` from being parsed as a timestamp, resulting in nothing being parsed.

I'm not sure why spaces were allowed before, so I won't handle spaces in this scenario.