### PR TITLE
Add new tab functionality to RunCommand extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ scratch/
 bun.lockb
 bun.lock
 package-lock.json
+CLAUDE.md

--- a/source/RunCommand.popclipext/Config.json
+++ b/source/RunCommand.popclipext/Config.json
@@ -50,6 +50,13 @@
       "type": "string",
       "identifier": "append",
       "description": "Text to insert after the selected text (optional)"
+    },
+    {
+      "label": "Use New Tab",
+      "type": "boolean",
+      "identifier": "newtab",
+      "description": "Open command in a new tab instead of current tab",
+      "defaultValue": false
     }
   ]
 }

--- a/source/RunCommand.popclipext/Config.json
+++ b/source/RunCommand.popclipext/Config.json
@@ -1,6 +1,6 @@
 {
-  "name": "Terminal",
-  "identifier": "com.pilotmoon.popclip.extension.rtc",
+  "name": "Terminal+",
+  "identifier": "com.shayonpal.popclip.runcommand.enhanced",
   "description": "Run the selected text as a command in the active terminal window with optional prepend/append text. Supports Terminal, iTerm2 and Warp.",
   "keywords": "terminal iterm2 warp run command",
   "popclip version": 4151,

--- a/source/RunCommand.popclipext/Config.json
+++ b/source/RunCommand.popclipext/Config.json
@@ -1,7 +1,7 @@
 {
   "name": "Terminal",
   "identifier": "com.pilotmoon.popclip.extension.rtc",
-  "description": "Run the selected text as a command in the active terminal window. Supports Terminal, iTerm2 and Warp.",
+  "description": "Run the selected text as a command in the active terminal window with optional prepend/append text. Supports Terminal, iTerm2 and Warp.",
   "keywords": "terminal iterm2 warp run command",
   "popclip version": 4151,
   "icon": "RTC.png",
@@ -38,6 +38,18 @@
       "values": ["Terminal", "iTerm2 v2.9+", "Warp"],
       "valueLabels": ["Terminal", "iTerm2", "Warp"],
       "identifier": "term"
+    },
+    {
+      "label": "Prepend Command",
+      "type": "string",
+      "identifier": "prepend",
+      "description": "Text to insert before the selected text (optional)"
+    },
+    {
+      "label": "Append Command",
+      "type": "string",
+      "identifier": "append",
+      "description": "Text to insert after the selected text (optional)"
     }
   ]
 }

--- a/source/RunCommand.popclipext/README.md
+++ b/source/RunCommand.popclipext/README.md
@@ -9,6 +9,7 @@ One can choose either default Terminal, [iTerm2](https://iterm2.com/) or [Warp](
 - Execute selected text as a command in your terminal of choice
 - Optionally prepend text before the selected command
 - Optionally append text after the selected command
+- Run commands in a new tab instead of the current tab
 
 ### Usage Examples
 
@@ -30,6 +31,7 @@ In the extension settings, you can configure:
 - Terminal Emulator: Choose between Terminal, iTerm2, or Warp
 - Prepend Command: Text to insert before the selected text (optional)
 - Append Command: Text to insert after the selected text (optional)
+- Use New Tab: Opens command in a new tab instead of the current tab
 
 ### About
 
@@ -37,6 +39,7 @@ Original extension and icon created by [James Smith](https://twitter.com/smithjw
 
 ## Changelog
 
+- 28 May 2025: Added 'Use New Tab' option to run commands in a new terminal tab
 - 28 May 2025: Added prepend/append functionality to customize command execution
 - 9 Nov 2024: Remove needless line from iTerm2 script
 - 21 May 2024: Add filter keywords for directory and update readme.

--- a/source/RunCommand.popclipext/README.md
+++ b/source/RunCommand.popclipext/README.md
@@ -4,12 +4,40 @@ Runs the selected text as a command in the current terminal window.
 
 One can choose either default Terminal, [iTerm2](https://iterm2.com/) or [Warp](https://www.warp.dev/).
 
+## Features
+
+- Execute selected text as a command in your terminal of choice
+- Optionally prepend text before the selected command
+- Optionally append text after the selected command
+
+### Usage Examples
+
+1. **Basic command execution**:  
+   Select a command like `ls -la` and run it directly.
+
+2. **Prepend example**:  
+   Set "Prepend Command" to `sudo` to run selected commands with sudo privileges.
+
+3. **Append example**:  
+   Set "Append Command" to `| grep keyword` to filter command output.
+
+4. **Combining prepend and append**:  
+   Set "Prepend Command" to `sudo` and "Append Command" to `| tee output.log` to run with sudo and save output to a file.
+
+## Configuration
+
+In the extension settings, you can configure:
+- Terminal Emulator: Choose between Terminal, iTerm2, or Warp
+- Prepend Command: Text to insert before the selected text (optional)
+- Append Command: Text to insert after the selected text (optional)
+
 ### About
 
-Original extension and icon created by [James Smith](https://twitter.com/smithjw/status/244757999665700864). iTerm2 option added by [honnix](https://github.com/honnix). Warp support added by Oliver using script from [parterburn](https://gist.github.com/parterburn/e832b9090ee35eb830529de8bd978b82).
+Original extension and icon created by [James Smith](https://twitter.com/smithjw/status/244757999665700864). iTerm2 option added by [honnix](https://github.com/honnix). Warp support added by Oliver using script from [parterburn](https://gist.github.com/parterburn/e832b9090ee35eb830529de8bd978b82). Prepend/append functionality added by Shayon Pal.
 
 ## Changelog
 
+- 28 May 2025: Added prepend/append functionality to customize command execution
 - 9 Nov 2024: Remove needless line from iTerm2 script
 - 21 May 2024: Add filter keywords for directory and update readme.
 - 28 Mar 2024: Removed the legacy iTerm option and added Warp Terminal.

--- a/source/RunCommand.popclipext/iterm2.applescript
+++ b/source/RunCommand.popclipext/iterm2.applescript
@@ -2,7 +2,20 @@
 tell application id "com.googlecode.iterm2"
 	activate
 	set _session to current session of current window
+	
+	-- Prepare the command with optional prepend/append text
+	set prepend_text to "{popclip option prepend}"
+	set append_text to "{popclip option append}"
+	
 	tell _session
-		write text "{popclip text}"
+		if prepend_text is not "" and append_text is not "" then
+			write text prepend_text & " {popclip text} " & append_text
+		else if prepend_text is not "" then
+			write text prepend_text & " {popclip text}"
+		else if append_text is not "" then
+			write text "{popclip text} " & append_text
+		else
+			write text "{popclip text}"
+		end if
 	end tell
 end tell

--- a/source/RunCommand.popclipext/iterm2.applescript
+++ b/source/RunCommand.popclipext/iterm2.applescript
@@ -1,20 +1,35 @@
--- new version of script for iTerm2 v2.9+
+-- AppleScript for iTerm2 (v2.9+) integration with PopClip
+-- This script takes the selected text from PopClip and sends it to iTerm2
+-- It uses the application ID to ensure proper identification of iTerm2
+
 tell application id "com.googlecode.iterm2"
+	-- Bring iTerm2 to the foreground
 	activate
+	
+	-- Get a reference to the current terminal session
+	-- This targets the active session in the frontmost window
 	set _session to current session of current window
 	
-	-- Prepare the command with optional prepend/append text
+	-- Retrieve optional prefix and suffix text from PopClip extension settings
+	-- These allow customizing the command with text before or after the selection
 	set prepend_text to "{popclip option prepend}"
 	set append_text to "{popclip option append}"
 	
+	-- Target the current session to send our commands
 	tell _session
+		-- Handle different combinations of prepend/append text
+		-- and construct the final command to execute
 		if prepend_text is not "" and append_text is not "" then
+			-- Both prepend and append text are provided
 			write text prepend_text & " {popclip text} " & append_text
 		else if prepend_text is not "" then
+			-- Only prepend text is provided
 			write text prepend_text & " {popclip text}"
 		else if append_text is not "" then
+			-- Only append text is provided
 			write text "{popclip text} " & append_text
 		else
+			-- No prepend or append text, just run the selected text as a command
 			write text "{popclip text}"
 		end if
 	end tell

--- a/source/RunCommand.popclipext/iterm2.applescript
+++ b/source/RunCommand.popclipext/iterm2.applescript
@@ -6,6 +6,17 @@ tell application id "com.googlecode.iterm2"
 	-- Bring iTerm2 to the foreground
 	activate
 	
+	-- Get the "Use New Tab" option
+	set use_new_tab to "{popclip option newtab}" is "1"
+	
+	-- Create a new tab if requested
+	if use_new_tab then
+		tell current window
+			create tab with default profile
+		end tell
+		delay 0.5 -- Give the new tab time to initialize
+	end if
+	
 	-- Get a reference to the current terminal session
 	-- This targets the active session in the frontmost window
 	set _session to current session of current window

--- a/source/RunCommand.popclipext/terminal.applescript
+++ b/source/RunCommand.popclipext/terminal.applescript
@@ -5,9 +5,23 @@ tell application "Terminal"
     -- Bring Terminal to the foreground
     activate
     
-    -- If there are no open windows, create a new Terminal window
+    -- Get the "Use New Tab" option
+    set use_new_tab to "{popclip option newtab}" is "1"
+    
+    -- If there are no open windows, open one.
     if (count of windows) is less than 1 then
         do script ""
+        set use_new_tab to false -- No need for new tab if we just opened a window
+    end if
+    
+    -- Create a new tab if requested
+    if use_new_tab then
+        tell application "System Events"
+            tell process "Terminal"
+                keystroke "t" using command down
+            end tell
+        end tell
+        delay 0.5 -- Give the new tab time to initialize
     end if
     
     -- Get a reference to the currently active tab in the first window

--- a/source/RunCommand.popclipext/terminal.applescript
+++ b/source/RunCommand.popclipext/terminal.applescript
@@ -1,22 +1,36 @@
+-- AppleScript for macOS Terminal app integration with PopClip
+-- This script takes the selected text from PopClip and runs it as a command in Terminal
+
 tell application "Terminal"
+    -- Bring Terminal to the foreground
     activate
-    -- If there are no open windows, open one.
+    
+    -- If there are no open windows, create a new Terminal window
     if (count of windows) is less than 1 then
         do script ""
     end if
+    
+    -- Get a reference to the currently active tab in the first window
     set theTab to selected tab in first window
     
-    -- Prepare the command with optional prepend/append text
+    -- Retrieve optional prefix and suffix text from PopClip extension settings
+    -- These allow customizing the command with text before or after the selection
     set prepend_text to "{popclip option prepend}"
     set append_text to "{popclip option append}"
     
+    -- Handle different combinations of prepend/append text
+    -- and construct the final command to execute
     if prepend_text is not "" and append_text is not "" then
+        -- Both prepend and append text are provided
         do script prepend_text & " {popclip text} " & append_text in theTab
     else if prepend_text is not "" then
+        -- Only prepend text is provided
         do script prepend_text & " {popclip text}" in theTab
     else if append_text is not "" then
+        -- Only append text is provided
         do script "{popclip text} " & append_text in theTab
     else
+        -- No prepend or append text, just run the selected text as a command
         do script "{popclip text}" in theTab
     end if
 end tell

--- a/source/RunCommand.popclipext/terminal.applescript
+++ b/source/RunCommand.popclipext/terminal.applescript
@@ -5,5 +5,18 @@ tell application "Terminal"
         do script ""
     end if
     set theTab to selected tab in first window
-    do script "{popclip text}" in theTab
+    
+    -- Prepare the command with optional prepend/append text
+    set prepend_text to "{popclip option prepend}"
+    set append_text to "{popclip option append}"
+    
+    if prepend_text is not "" and append_text is not "" then
+        do script prepend_text & " {popclip text} " & append_text in theTab
+    else if prepend_text is not "" then
+        do script prepend_text & " {popclip text}" in theTab
+    else if append_text is not "" then
+        do script "{popclip text} " & append_text in theTab
+    else
+        do script "{popclip text}" in theTab
+    end if
 end tell

--- a/source/RunCommand.popclipext/warp.applescript
+++ b/source/RunCommand.popclipext/warp.applescript
@@ -59,4 +59,17 @@ else
 end if
 
 call_forward()
-send_text("{popclip text}")
+
+-- Prepare the command with optional prepend/append text
+set prepend_text to "{popclip option prepend}"
+set append_text to "{popclip option append}"
+
+if prepend_text is not "" and append_text is not "" then
+	send_text(prepend_text & " {popclip text} " & append_text)
+else if prepend_text is not "" then
+	send_text(prepend_text & " {popclip text}")
+else if append_text is not "" then
+	send_text("{popclip text} " & append_text)
+else
+	send_text("{popclip text}")
+end if

--- a/source/RunCommand.popclipext/warp.applescript
+++ b/source/RunCommand.popclipext/warp.applescript
@@ -72,12 +72,15 @@ end send_text
 -- First activate Warp and bring it to the foreground
 call_forward()
 
+-- Get the "Use New Tab" option from PopClip
+set use_new_tab to "{popclip option newtab}" is "1"
+
 -- Determine where to send the command based on configuration
 if open_in_new_window then
 	-- Create a new window if configured to do so
 	new_window()
-else if open_in_new_tab then
-	-- Create a new tab if configured to do so
+else if use_new_tab then
+	-- Create a new tab if requested via PopClip option
 	new_tab()
 else
 	-- Otherwise reuse the current tab (no action needed)

--- a/source/RunCommand.popclipext/warp.applescript
+++ b/source/RunCommand.popclipext/warp.applescript
@@ -1,13 +1,18 @@
+-- AppleScript for Warp Terminal integration with PopClip
+-- This script takes the selected text from PopClip and sends it to Warp Terminal
 -- For the latest version:
 -- https://gist.github.com/parterburn/e832b9090ee35eb830529de8bd978b82
 
+-- Configuration Properties
 -- Set this property to true to always open in a new window
 property open_in_new_window : false
 
 -- Set this property to false to reuse the current tab
 property open_in_new_tab : false
 
--- Handlers
+-- ========== Handler Definitions ==========
+
+-- Creates a new Warp window using keyboard shortcut Cmd+N
 on new_window()
 	tell application "System Events"
 		tell process "Warp"
@@ -16,6 +21,7 @@ on new_window()
 	end tell
 end new_window
 
+-- Creates a new tab in the current Warp window using keyboard shortcut Cmd+T
 on new_tab()
 	tell application "System Events"
 		tell process "Warp"
@@ -24,9 +30,14 @@ on new_tab()
 	end tell
 end new_tab
 
+-- Activates Warp and brings it to the foreground
+-- This ensures commands are sent to the correct application
 on call_forward()
 	tell application "Warp"
+		-- Launch Warp if not running or bring to front if it is
 		activate
+		
+		-- Ensure Warp is the frontmost application using System Events
 		tell application "System Events"
 			tell process "Warp"
 				set frontmost to true
@@ -35,41 +46,63 @@ on call_forward()
 	end tell
 end call_forward
 
+-- Sends text to Warp and executes it by pressing Return (key code 36)
+-- The delays help ensure the terminal is ready for input
 on send_text(custom_text)
 	tell application "System Events"
 		tell process "Warp"
+			-- Small delay to ensure Warp is ready
 			delay 0.5
+			
+			-- Type the text into Warp
 			keystroke custom_text
+			
+			-- Small delay before pressing Return
 			delay 0.5
+			
+			-- Press Return to execute the command
+			-- Key code 36 is the Return key
 			key code 36
 		end tell
 	end tell
 end send_text
 
--- Main
+-- ========== Main Program ==========
 
+-- First activate Warp and bring it to the foreground
 call_forward()
 
+-- Determine where to send the command based on configuration
 if open_in_new_window then
+	-- Create a new window if configured to do so
 	new_window()
 else if open_in_new_tab then
+	-- Create a new tab if configured to do so
 	new_tab()
 else
-	-- Reuse the current tab
+	-- Otherwise reuse the current tab (no action needed)
 end if
 
+-- Ensure Warp is still in focus after potential window/tab changes
 call_forward()
 
--- Prepare the command with optional prepend/append text
+-- Retrieve optional prefix and suffix text from PopClip extension settings
+-- These allow customizing the command with text before or after the selection
 set prepend_text to "{popclip option prepend}"
 set append_text to "{popclip option append}"
 
+-- Handle different combinations of prepend/append text
+-- and construct the final command to execute
 if prepend_text is not "" and append_text is not "" then
+	-- Both prepend and append text are provided
 	send_text(prepend_text & " {popclip text} " & append_text)
 else if prepend_text is not "" then
+	-- Only prepend text is provided
 	send_text(prepend_text & " {popclip text}")
 else if append_text is not "" then
+	-- Only append text is provided
 	send_text("{popclip text} " & append_text)
 else
+	-- No prepend or append text, just run the selected text as a command
 	send_text("{popclip text}")
 end if


### PR DESCRIPTION
## Summary
- Adds 'Use New Tab' option to RunCommand extension
- Implements tab creation functionality in Terminal.app, iTerm2, and Warp
- Updates documentation with new option details

## Test plan
- Test with all three terminal emulators (Terminal, iTerm2, Warp)
- Verify both current tab and new tab functionality works
- Check different combinations of prepend/append options with new tab option

Closes #3