### PR TITLE
OpenAI Chat (API) improvements

### DIFF
--- a/source/OpenAIChat.popclipext/Config.ts
+++ b/source/OpenAIChat.popclipext/Config.ts
@@ -26,6 +26,12 @@ export const options = [
 		values: ["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "o3", "o3-mini", "o4-mini"],
 	},
 	{
+    identifier: "customModel",
+    label: "Custom Model",
+    type: "string",
+    description: "Enter a custom model name. See actual list here https://platform.openai.com/docs/models",
+  },
+	{
 		identifier: "systemMessage",
 		label: "System Message",
 		type: "string",
@@ -129,7 +135,7 @@ const chat: ActionFunction<Options> = async (input, options) => {
 	// send the whole message history to OpenAI
 	try {
 		const { data }: Response = await openai.post("chat/completions", {
-			model: options.model || "gpt-3.5-turbo",
+			model: options.customModel || options.model || "gpt-4.1-nano",
 			messages,
 		});
 

--- a/source/OpenAIChat.popclipext/Readme.md
+++ b/source/OpenAIChat.popclipext/Readme.md
@@ -96,7 +96,7 @@ Icons:
 
 ## Changelog
 
-- 2025-06-18: Add `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `o3`, `o4-mini`. Set default to `gpt-4.1-nano`. Remove `o1`, `o3-mini` `gpt-4o-mini` models from list.
+- 2025-06-18: Add "Custom model" setting. Add `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `o3`, `o4-mini`. Set default to `gpt-4.1-nano`. Remove `o1`, `o3-mini` `gpt-4o-mini` models from list.
 - 2025-02-04: Add `o1` and `o3-mini` models. Set default to `gpt-4o-mini`. Remove `gpt-3.5-turbo`, `gpt-4`, `gpt-4-turbo` and `o1-preview` models from list.
 - 2024-11-20: Add `o1-preview` and `o1-mini` models.
 - 2024-11-15: Add "Copy" tp Response Handcling options.


### PR DESCRIPTION
I actualized OpenAI models – `o1-mini` are deprecated, another ones have knownledge cutoff in 2024.

And I add option for custom model name. Maybe someone wans to use specific models or maybe even custom GPT with [RAG](https://help.openai.com/en/articles/8868588-retrieval-augmented-generation-rag-and-semantic-search-for-gpts). The presence of this option will require less frequent updates because users can enter model names on their own.

I'm not sure which link in description will be more useful – [Models](https://platform.openai.com/docs/models) or [Pricing](https://platform.openai.com/docs/pricing)
