### PR TITLE
feat(OpenAIChat): support custom API base path for OpenAI-compatible APIs

### DIFF
--- a/source/OpenAIChat.popclipext/Config.ts
+++ b/source/OpenAIChat.popclipext/Config.ts
@@ -53,7 +53,7 @@ export const options = [
     identifier: "domain",
     label: "API Base Domain",
     type: "string",
-    defaultValue: "api.openai.com",
+    defaultValue: "api.openai.com/v1",
     description: "Leave as default unless you use a custom server.",
   },
   {
@@ -120,7 +120,7 @@ function getTranscript(n: number): string {
 // the main chat action
 const chat: ActionFunction<Options> = async (input, options) => {
   const openai = axios.create({
-    baseURL: `https://${options.domain}/v1`,
+    baseURL: `https://${options.domain}`,
     headers: { Authorization: `Bearer ${options.apikey}` },
   });
 

--- a/source/OpenAIChat.popclipext/Readme.md
+++ b/source/OpenAIChat.popclipext/Readme.md
@@ -59,8 +59,14 @@ specified.
 
 #### API Base Domain
 
-The base domain for the OpenAI API. This should be `api.openai.com` unless you
-are using a custom domain to access the API.
+The base URL path for the API. The default is `api.openai.com/v1` for OpenAI.
+
+You can change this to use other OpenAI-compatible APIs:
+
+- **OpenAI**: `api.openai.com/v1` (default)
+- **Google Gemini**: `generativelanguage.googleapis.com/v1beta/openai`
+- **Azure OpenAI**: `YOUR_RESOURCE.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT`
+- **Other providers**: Check their documentation for the OpenAI-compatible endpoint
 
 #### Response Handling
 
@@ -105,6 +111,8 @@ Icons:
 
 ## Changelog
 
+- 2025-12-03: Allow full API base path for better compatibility with
+  OpenAI-compatible APIs (Gemini, Azure, etc.).
 - 2025-09-19: Change default model to `gpt-5-nano` (currently the cheapest).
 - 2025-08-20: Add `gpt-5`, `gpt-5-mini`, `gpt-5-nano` to drop-down.
 - 2025-06-18: Add "Custom Model" setting. Add `gpt-4.1`, `gpt-4.1-mini`,


### PR DESCRIPTION

Allow users to specify the full API base path instead of hardcoding /v1, enabling compatibility with various OpenAI-compatible APIs like Google Gemini, Azure OpenAI, and other providers.

- Change default from "api.openai.com" to "api.openai.com/v1"
- Remove hardcoded "/v1" suffix from baseURL construction
- Update documentation with examples for different providers