### PR TITLE
Handle timestamps formatted as milliseconds

### DIFF
--- a/source/UnixTime.popclipext/test.js
+++ b/source/UnixTime.popclipext/test.js
@@ -3,16 +3,22 @@
 const { test } = require("./unixtime")
 
 const testData = new Map([	
-	[["1535438729", 'UTC', 'zu'] , "2018-08-28 06:45:29 UTC"],
-	[["1535438729", 'Europe/London', 'gb'] , "28/08/2018, 07:45:29 BST"],
-	[["1535438729", 'America/New_York', 'zu'] , "2018-08-28 02:45:29 GMT-4"],
-	[["1535438729", 'Pacific/Honolulu', 'zu'] , "2018-08-27 20:45:29 GMT-10"],
+	[["1535438729", 'UTC', 'zu', false] , "2018-08-28 06:45:29 UTC"],
+	[["1535438729", 'Europe/London', 'gb', false] , "28/08/2018, 07:45:29 BST"],
+	[["1535438729", 'America/New_York', 'zu', false] , "2018-08-28 02:45:29 GMT-4"],
+	[["1535438729", 'Pacific/Honolulu', 'zu', false] , "2018-08-27 20:45:29 GMT-10"],
+	[["2147483647", "UTC", "zu", false], "2038-01-19 03:14:07 UTC"],
+	[["4294967295", "UTC", "zu", false], "2106-02-07 06:28:15 UTC"],
+	[["2147483647000", "UTC", "zu", false], "+070021-01-17 19:16:40 UTC"],
+	[["4294967295000", "UTC", "zu", false], "+138072-02-04 14:50:00 UTC"],
+	[["2147483647000", "UTC", "zu", true], "2038-01-19 03:14:07 UTC"],
+	[["4294967295000", "UTC", "zu", true], "2106-02-07 06:28:15 UTC"],
 ]);
 
 let fail = false;
 
 testData.forEach((expect, testValue) => {
-	const result = test(testValue[0], {timeZone: testValue[1], locale:testValue[2]});
+	const result = test(testValue[0], {timeZone: testValue[1], locale:testValue[2], handleMilliseconds:testValue[3]});
 	const pass = result === expect;
 	if (!pass) {
 		fail = true;

--- a/source/UnixTime.popclipext/unixtime.js
+++ b/source/UnixTime.popclipext/unixtime.js
@@ -12,7 +12,7 @@ const systemSetting = ["", "System"];
 
 const process = (selection, options) => {
 	const unixTime = selection.replace(/\s/g, ''); // remove spaces;
-	const date = convert(unixTime);
+	const date = convert(unixTime, options.handleMilliseconds);
 
 	const custom_settings = (options.timeZone !== defaultTimezone[0] || options.locale !== defaultLocale[0])
 	if (custom_settings) {
@@ -26,7 +26,10 @@ const process = (selection, options) => {
 	return standardize(date, true)
 }
 
-const convert = (unixTime) => {
+const convert = (unixTime, handleMilliseconds) => {
+	if (handleMilliseconds && unixTime > 2 ** 32 - 1) {
+		return new Date(Number(unixTime));
+	}
 	const seconds = unixTime;
 	const milliseconds = 1000;
 	return new Date(seconds * milliseconds)
@@ -75,6 +78,12 @@ module.exports = {
 			type: 'multiple',
 			values: [defaultTimezone[0], systemSetting[0]].concat(Array.from(TIMEZONES.values())),
 			valueLabels: [defaultTimezone[1], systemSetting[1]].concat(Array.from(TIMEZONES.keys()))
+		},
+		{
+			identifier: "handleMilliseconds",
+			label: "Automatically handle milliseconds",
+			type: "boolean",
+			default: true,
 		}
 	],
 	test: process


### PR DESCRIPTION
I stumble across a _lot_ of timestamps formatted as milliseconds since the Unix epoch, not seconds. Concretely, instead of the current timestamp being `1765233417`, they're displayed as `1765233417000`.

This handles that case. If the new `handleMilliseconds` config option is set, then timestamps greater than the largest unsigned 32-bit integer value are _not_ multiplied by 1000. They're passed to `new Date()` as-is.

A couple of notes:

* I think this should be enabled by default. When someone looks at a timestamp in milliseconds, they're not usually expecting a datestamp in the year 70021 or so.
* I went with 2**32-1 — 2106-02-07 — because you have to pick _some_ threshold for when to treat a number as seconds or milliseconds, and that seemed sufficiently far out, and it can be disabled by our great great grandchildren who are bumping up against the Y2106 bug. They can ask their AI overlords to fix this for them then.