### PR TITLE
Add GitHub Search extension

### DIFF
--- a/contrib/GitHubSearch.popclipext/Config.yaml
+++ b/contrib/GitHubSearch.popclipext/Config.yaml
@@ -1,0 +1,13 @@
+# popclip
+name: GitHub Search
+identifier: com.github.search
+description: Search GitHub for repositories, code, issues, or users
+icon: iconify:mdi:github
+url: https://github.com/search?q=***&type={popclip option searchType}
+options:
+  - identifier: searchType
+    label: 搜索类型
+    type: multiple
+    values: [repositories, code, issues, users]
+    valueLabels: [仓库, 代码, Issues, 用户]
+    defaultValue: repositories

--- a/contrib/GitHubSearch.popclipext/README.md
+++ b/contrib/GitHubSearch.popclipext/README.md
@@ -1,7 +1,42 @@
-Search more than 7.2M Repositories on Github.
---------------------------------------------
+# GitHub Search
 
-### Cantact me
+Quickly search GitHub for the selected text.
 
-  * FangDun Cai <cfddream@gmail.com>
-  * http://kissdry.com/
+## Usage
+
+1. Select any text in any application
+2. Click the GitHub icon in the PopClip bar
+3. Search results will open in your default browser
+
+## Configuration
+
+You can choose what to search for in the extension settings:
+
+- **Repositories** (default) - Search for GitHub repositories
+- **Code** - Search within code files
+- **Issues** - Search issues and pull requests  
+- **Users** - Search GitHub users
+
+To change the search type:
+
+1. Open PopClip preferences
+2. Find "GitHub Search" in the extensions list
+3. Click the settings icon
+4. Select your preferred search type
+
+## Examples
+
+- Select `react hooks` → searches for repositories matching "react hooks"
+- Select `useState` and switch to Code mode → searches for code files containing "useState"
+- Select `torvalds` and switch to Users mode → searches for GitHub users
+
+## Author
+
+Created by dxz
+
+## Changelog
+
+### 1.0.0 - 2026-01-19
+- Initial release
+- Support for searching repositories, code, issues, and users
+- Configurable search type via extension settings


### PR DESCRIPTION
This extension allows users to quickly search GitHub for the selected text.

Features:
- Search GitHub repositories (default)
- Search code files
- Search issues and pull requests
- Search users

The search type can be configured in the extension settings.