### PR TITLE
feat(MermaidPreview): add Mermaid Preview extension

### DIFF
--- a/contrib/MermaidPreview.popclipext/Config.yaml
+++ b/contrib/MermaidPreview.popclipext/Config.yaml
@@ -1,0 +1,9 @@
+name: Mermaid Preview
+identifier: com.custom.popclip.extension.mermaid_preview
+description: Preview mermaid diagrams
+icon: square filled M
+actions:
+  - title: mermaid preview
+    interpreter: /bin/zsh
+    stoppable: true
+    shellScriptFile: mermaid_preview.zsh

--- a/contrib/MermaidPreview.popclipext/README.md
+++ b/contrib/MermaidPreview.popclipext/README.md
@@ -1,0 +1,21 @@
+# Mermaid Preview
+
+Preview Mermaid diagrams from selected text using macOS Quick Look.
+
+## Usage
+
+Select Mermaid diagram syntax and click the extension to preview. Supports:
+
+- Raw Mermaid syntax
+- Markdown code blocks (` ```mermaid ... ``` `)
+- Unclosed code blocks (` ```mermaid ... `)
+
+## Rendering
+
+If [mermaid-cli](https://github.com/mermaid-js/mermaid-cli) (`mmdc`) is installed locally, it will be used for rendering. Otherwise, falls back to the [mermaid.ink](https://mermaid.ink) online service.
+
+### Install mermaid-cli (optional)
+
+```sh
+npm install -g @mermaid-js/mermaid-cli
+```

--- a/contrib/MermaidPreview.popclipext/mermaid_preview.zsh
+++ b/contrib/MermaidPreview.popclipext/mermaid_preview.zsh
@@ -1,0 +1,12 @@
+TEMP_FILE="${TMPDIR}mermaid_$(/usr/bin/uuidgen).svg"
+
+# Extract mermaid content from code block if present (```mermaid...```), otherwise use original text
+INPUT=$(echo "$POPCLIP_TEXT" | perl -0777 -ne 'print /```mermaid\s*(.*?)(?:```|$)/s ? $1 : $_')
+
+if command -v mmdc &> /dev/null; then
+    echo "$INPUT" | mmdc -i - -o - -e svg > "$TEMP_FILE" || exit 1
+else
+    BASE64_STRING=$(echo -n "$INPUT" | /usr/bin/base64 -b 0 | tr '+/' '-_' | tr -d '=')
+    /usr/bin/curl -sf "https://mermaid.ink/svg/${BASE64_STRING}" -o "$TEMP_FILE" || exit 1
+fi
+qlmanage -p "${TEMP_FILE}" &>/dev/null &

--- a/contrib/MermaidPreview.popclipext/mermaid_preview.zsh
+++ b/contrib/MermaidPreview.popclipext/mermaid_preview.zsh
@@ -9,4 +9,4 @@ else
     BASE64_STRING=$(echo -n "$INPUT" | /usr/bin/base64 -b 0 | tr '+/' '-_' | tr -d '=')
     /usr/bin/curl -sf "https://mermaid.ink/svg/${BASE64_STRING}" -o "$TEMP_FILE" || exit 1
 fi
-qlmanage -p "${TEMP_FILE}" &>/dev/null &
+./qlf.swift "$TEMP_FILE" &>/dev/null &

--- a/contrib/MermaidPreview.popclipext/qlf.swift
+++ b/contrib/MermaidPreview.popclipext/qlf.swift
@@ -1,0 +1,79 @@
+#!/usr/bin/env swift
+
+import Cocoa
+import QuickLookUI
+
+class FloatingPreview: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDelegate {
+  let urls: [URL]
+
+  init(paths: [String]) {
+    self.urls = paths.compactMap { path -> URL? in
+      let url = URL(fileURLWithPath: path)
+      guard FileManager.default.fileExists(atPath: path) else {
+        return nil
+      }
+      return url
+    }
+    super.init()
+  }
+
+  func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
+    return urls.count
+  }
+
+  func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> QLPreviewItem! {
+    return urls[index] as QLPreviewItem
+  }
+
+  @objc private func panelWillClose(_ notification: Notification) {
+    NSApp.terminate(nil)
+  }
+
+  func previewPanel(_ panel: QLPreviewPanel!, handle event: NSEvent!) -> Bool {
+    guard event.type == .keyDown else { return false }
+    switch event.keyCode {
+    case 49, 53:  // Space, Esc
+      panel.close()
+      return true
+    default:
+      return false
+    }
+  }
+
+  func run() {
+    guard !urls.isEmpty else {
+      exit(1)
+    }
+
+    let app = NSApplication.shared
+    app.setActivationPolicy(.accessory)
+
+    guard let panel = QLPreviewPanel.shared() else {
+      exit(1)
+    }
+    panel.dataSource = self
+    panel.delegate = self
+    panel.level = .floating  // This makes it float above full-screen apps
+    panel.hidesOnDeactivate = false
+    panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(panelWillClose(_:)),
+      name: NSWindow.willCloseNotification,
+      object: panel
+    )
+    panel.makeKeyAndOrderFront(nil)
+
+    app.activate(ignoringOtherApps: true)
+    app.run()
+  }
+}
+
+guard CommandLine.arguments.count > 1 else {
+  print("Usage: qlf <file> [file2] ...")
+  exit(1)
+}
+
+let paths = Array(CommandLine.arguments.dropFirst())
+let preview = FloatingPreview(paths: paths)
+preview.run()


### PR DESCRIPTION
## Background

AI assistants (like ChatGPT, Claude, etc.) often generate Mermaid diagram syntax in their responses. This extension allows users to quickly preview these diagrams without leaving their workflow.

## Summary

- Add Mermaid Preview extension that renders Mermaid diagrams using macOS Quick Look
- Supports raw Mermaid syntax, markdown code blocks (` ```mermaid...``` `), and unclosed code blocks
- Uses local mermaid-cli (`mmdc`) if available, otherwise falls back to mermaid.ink



https://github.com/user-attachments/assets/60b85c48-8e8e-4a7a-b006-9e73eb166697





