### PR TITLE
Add ChatGPT Prompt extension to contrib

### DIFF
--- a/contrib/ChatGPTPrompt.popclipext/Config.json
+++ b/contrib/ChatGPTPrompt.popclipext/Config.json
@@ -1,0 +1,16 @@
+{
+  "name": "ChatGPT Prompt",
+  "identifier": "com.gravitypoet.popclip.extension.chatgpt-prompt",
+  "description": "Ask a follow-up question on selected text and send it directly to ChatGPT.",
+  "icon": "square filled scale=85 iconify:simple-icons:openai",
+  "title": "\u200B",
+  "popclipVersion": 4586,
+  "app": {
+    "name": "ChatGPT",
+    "link": "https://chatgpt.com/"
+  },
+  "requirements": [
+    "text"
+  ],
+  "applescriptFile": "chatgpt.applescript"
+}

--- a/contrib/ChatGPTPrompt.popclipext/Readme.md
+++ b/contrib/ChatGPTPrompt.popclipext/Readme.md
@@ -1,0 +1,40 @@
+# ChatGPT Prompt
+
+A PopClip extension that adds a follow-up question dialog before sending selected text directly to ChatGPT.
+
+## How to use
+
+1. Select text in any app.
+2. Click the ChatGPT icon in PopClip.
+3. Enter your follow-up question in the popup dialog.
+4. ChatGPT opens with a prefilled prompt and sends via `q` URL flow.
+
+## Prompt format
+
+```text
+【原文】
+<selected text>
+
+【问题】
+<your question>
+```
+
+## Advantages vs ChatGPT Website extension (73pbck)
+
+Compared with [ChatGPT Website](https://www.popclip.app/extensions/x/73pbck):
+
+1. Adds an inline question dialog so you can add intent before sending.
+2. Keeps direct-send behavior by using the same `https://chatgpt.com/?q=` path.
+3. Uses a structured prompt format to improve context quality for long/complex selections.
+
+## Requirements
+
+- ChatGPT web access (`https://chatgpt.com/`)
+
+## Author
+
+- GravityPoet
+
+## Changelog
+
+- 2026-02-18 Initial release

--- a/contrib/ChatGPTPrompt.popclipext/chatgpt.applescript
+++ b/contrib/ChatGPTPrompt.popclipext/chatgpt.applescript
@@ -8,18 +8,26 @@ on run
   if trimmedQuestion is "" then error "问题不能为空。" number 701
 
   set finalPrompt to "【原文】" & return & selectedText & return & return & "【问题】" & return & userQuestion
+  set the clipboard to finalPrompt
   set encodedPrompt to my urlEncode(finalPrompt)
   set targetURL to "https://chatgpt.com/?q=" & encodedPrompt
 
-  open location targetURL
+  try
+    tell application "Google Chrome"
+      activate
+      if (count of windows) is 0 then make new window
+      tell front window
+        make new tab at end of tabs with properties {URL:targetURL}
+        set active tab index to (count of tabs)
+      end tell
+    end tell
+  on error
+    do shell script "/usr/bin/open " & quoted form of targetURL
+  end try
 end run
 
 on trimText(rawText)
-  set text item delimiters to {space, tab, return, linefeed}
-  set parts to text items of rawText
-  set text item delimiters to ""
-  set cleaned to parts as text
-  set text item delimiters to ""
+  set cleaned to do shell script "/usr/bin/python3 -c " & quoted form of "import sys; print(sys.argv[1].strip())" & space & quoted form of rawText
   return cleaned
 end trimText
 

--- a/contrib/ChatGPTPrompt.popclipext/chatgpt.applescript
+++ b/contrib/ChatGPTPrompt.popclipext/chatgpt.applescript
@@ -1,0 +1,29 @@
+on run
+  set selectedText to "{popclip text}"
+  if selectedText is "" then error "No selected text found." number 700
+
+  set dialogResult to display dialog "请输入你想补充问 ChatGPT 的问题：" default answer "" buttons {"取消", "发送"} default button "发送" cancel button "取消"
+  set userQuestion to text returned of dialogResult
+  set trimmedQuestion to my trimText(userQuestion)
+  if trimmedQuestion is "" then error "问题不能为空。" number 701
+
+  set finalPrompt to "【原文】" & return & selectedText & return & return & "【问题】" & return & userQuestion
+  set encodedPrompt to my urlEncode(finalPrompt)
+  set targetURL to "https://chatgpt.com/?q=" & encodedPrompt
+
+  open location targetURL
+end run
+
+on trimText(rawText)
+  set text item delimiters to {space, tab, return, linefeed}
+  set parts to text items of rawText
+  set text item delimiters to ""
+  set cleaned to parts as text
+  set text item delimiters to ""
+  return cleaned
+end trimText
+
+on urlEncode(rawText)
+  set encoded to do shell script "/usr/bin/python3 -c " & quoted form of "import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1]))" & space & quoted form of rawText
+  return encoded
+end urlEncode


### PR DESCRIPTION
## Summary

Adds a new extension at `contrib/ChatGPTPrompt.popclipext`.

This extension keeps direct send behavior for ChatGPT while adding a dialog step to collect a follow-up question before sending.

## What it does

1. User selects text.
2. PopClip action opens a question dialog.
3. Extension composes:

```text
【原文】
<selected text>

【问题】
<follow-up question>
```

4. Opens `https://chatgpt.com/?q=...` to send through ChatGPT's URL flow.

## Advantages vs existing ChatGPT Website extension

Compared with `73pbck` (ChatGPT Website), this extension adds:

- Inline follow-up question dialog before sending.
- Structured prompt format for better context clarity.
- Same direct-send URL path (`q`) for simple no-clipboard workflow.

## Included files

- `Config.json`
- `chatgpt.applescript`
- `Readme.md`

## Manual test

- Verified popup dialog behavior.
- Verified URL encoding and ChatGPT URL opening.
- Verified AppleScript compiles on macOS.
