### PR TITLE
Add Copy as Plain Markdown extension

### DIFF
--- a/contrib/CopyAsPlainMarkdown.popclipext/Config.ts
+++ b/contrib/CopyAsPlainMarkdown.popclipext/Config.ts
@@ -5,38 +5,76 @@
 // icon: symbol:doc.plaintext
 // popclip version: 4615
 
-const linkedom = require("linkedom");
-const TurndownService = require("turndown");
+import * as linkedom from "linkedom";
+import TurndownService from "turndown";
 
-function htmlToMarkdown(html) {
+function htmlToMarkdown(html: string): string {
   const { document } = linkedom.parseHTML(html);
-  const td = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+  const td = new TurndownService({
+    headingStyle: "atx",
+    codeBlockStyle: "fenced",
+  });
   return td.turndown(document);
 }
 
-function simplifyMarkdown(md) {
+function protectCode(text: string) {
+  const codeBlocks: string[] = [];
+  let result = text.replace(/```[\s\S]*?```/g, (match) => {
+    codeBlocks.push(match);
+    return `\uFFFDCODEBLOCK${codeBlocks.length - 1}\uFFFD`;
+  });
+  const inlineCode: string[] = [];
+  result = result.replace(/`[^`]+`/g, (match) => {
+    inlineCode.push(match);
+    return `\uFFFDINLINE${inlineCode.length - 1}\uFFFD`;
+  });
+  return { result, codeBlocks, inlineCode };
+}
+
+function restoreCode(
+  text: string,
+  codeBlocks: string[],
+  inlineCode: string[],
+): string {
+  let result = text.replace(
+    /\uFFFDINLINE(\d+)\uFFFD/g,
+    (_, i) => inlineCode[i],
+  );
+  result = result.replace(
+    /\uFFFDCODEBLOCK(\d+)\uFFFD/g,
+    (_, i) => codeBlocks[i],
+  );
+  return result;
+}
+
+function simplifyMarkdown(md: string): string {
+  // Protect code blocks and inline code from transformation
+  const { result, codeBlocks, inlineCode } = protectCode(md);
+  let text = result;
+
   // Preserved as-is: blockquotes (>), indentation, bullets, numbered lists,
   // fenced code blocks, paragraphs, line breaks.
 
   // Remove heading markers (### Text -> Text), but keep inside blockquotes
-  md = md.replace(/^(>\s*)*#{1,6}\s+/gm, "$1");
+  text = text.replace(/^(>\s*)*#{1,6}\s+/gm, "$1");
+  // Remove bold+italic (***text***) before processing bold and italic separately
+  text = text.replace(/\*{3}(.+?)\*{3}/g, "$1");
   // Remove bold (**text** or __text__)
-  md = md.replace(/\*\*(.+?)\*\*/g, "$1");
-  md = md.replace(/__(.+?)__/g, "$1");
+  text = text.replace(/\*\*(.+?)\*\*/g, "$1");
+  text = text.replace(/__(.+?)__/g, "$1");
   // Remove italic (*text* or _text_)
-  md = md.replace(/(?<![*\w])\*([^*\n]+?)\*(?![*\w])/g, "$1");
-  md = md.replace(/(?<!_)_([^_\n]+?)_(?!_)/g, "$1");
+  text = text.replace(/(?<![*\w])\*([^*\n]+?)\*(?![*\w])/g, "$1");
+  text = text.replace(/(?<!_)_([^_\n]+?)_(?!_)/g, "$1");
   // Remove strikethrough (~~text~~)
-  md = md.replace(/~~(.+?)~~/g, "$1");
-  // Remove inline code backticks (`text` -> text)
-  md = md.replace(/`([^`]+)`/g, "$1");
+  text = text.replace(/~~(.+?)~~/g, "$1");
   // Remove images, keep alt text: ![alt](url) -> alt
-  md = md.replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1");
+  text = text.replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1");
   // Convert links to just text: [text](url) -> text
-  md = md.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+  text = text.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
   // Clean up multiple blank lines
-  md = md.replace(/\n{3,}/g, "\n\n");
-  return md.trim();
+  text = text.replace(/\n{3,}/g, "\n\n");
+
+  return restoreCode(text.trim(), codeBlocks, inlineCode);
 }
 
 exports.action = {

--- a/contrib/CopyAsPlainMarkdown.popclipext/Config.ts
+++ b/contrib/CopyAsPlainMarkdown.popclipext/Config.ts
@@ -1,0 +1,50 @@
+// #popclip
+// name: Copy as Plain Markdown
+// identifier: com.yulonglin.popclip.extension.copy-as-plain-markdown
+// description: Copy selected text as plain Markdown — structure without formatting.
+// icon: symbol:doc.plaintext
+// popclip version: 4615
+
+const linkedom = require("linkedom");
+const TurndownService = require("turndown");
+
+function htmlToMarkdown(html) {
+  const { document } = linkedom.parseHTML(html);
+  const td = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+  return td.turndown(document);
+}
+
+function simplifyMarkdown(md) {
+  // Preserved as-is: blockquotes (>), indentation, bullets, numbered lists,
+  // fenced code blocks, paragraphs, line breaks.
+
+  // Remove heading markers (### Text -> Text), but keep inside blockquotes
+  md = md.replace(/^(>\s*)*#{1,6}\s+/gm, "$1");
+  // Remove bold (**text** or __text__)
+  md = md.replace(/\*\*(.+?)\*\*/g, "$1");
+  md = md.replace(/__(.+?)__/g, "$1");
+  // Remove italic (*text* or _text_)
+  md = md.replace(/(?<![*\w])\*([^*\n]+?)\*(?![*\w])/g, "$1");
+  md = md.replace(/(?<!_)_([^_\n]+?)_(?!_)/g, "$1");
+  // Remove strikethrough (~~text~~)
+  md = md.replace(/~~(.+?)~~/g, "$1");
+  // Remove inline code backticks (`text` -> text)
+  md = md.replace(/`([^`]+)`/g, "$1");
+  // Remove images, keep alt text: ![alt](url) -> alt
+  md = md.replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1");
+  // Convert links to just text: [text](url) -> text
+  md = md.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+  // Clean up multiple blank lines
+  md = md.replace(/\n{3,}/g, "\n\n");
+  return md.trim();
+}
+
+exports.action = {
+  captureHtml: true,
+  code(input) {
+    const md = input.html
+      ? simplifyMarkdown(htmlToMarkdown(input.html))
+      : input.text;
+    popclip.copyText(md);
+  },
+};

--- a/contrib/CopyAsPlainMarkdown.popclipext/README.md
+++ b/contrib/CopyAsPlainMarkdown.popclipext/README.md
@@ -1,0 +1,30 @@
+# Copy as Plain Markdown
+
+Copy selected text as plain Markdown — preserving document structure
+(bullets, blockquotes, indentation, line breaks) while stripping inline
+formatting (bold, italic, headings, links, images, code spans).
+
+Useful for pasting into plain-text contexts where you want structure but not
+rich formatting noise.
+
+## What is preserved
+
+- Bullet lists
+- Numbered lists
+- Blockquotes (`>`)
+- Indentation
+- Paragraphs and line breaks
+- Code blocks (fenced)
+- Horizontal rules (`---`)
+
+## What is stripped
+
+- Bold / italic / strikethrough markers
+- Heading markers (`#`)
+- Links (kept as plain text)
+- Images (kept as alt text)
+- Inline code backticks
+
+## Author
+
+Lin Yulong


### PR DESCRIPTION
## Summary

- Copies selected rich text as **plain Markdown** — preserving structure (bullets, blockquotes, code blocks, indentation) while stripping inline formatting (bold, italic, headings, links, images)
- Uses linkedom + turndown for HTML→Markdown conversion, then regex post-processing to strip formatting markers
- Code blocks (fenced and inline) are protected from transformation
- Useful for pasting into plain-text contexts where you want structure but not rich formatting noise

## Files

- `contrib/CopyAsPlainMarkdown.popclipext/Config.ts`
- `contrib/CopyAsPlainMarkdown.popclipext/README.md`

## Test plan

- [x] Manually tested: select rich text in browser/Notion, click action, paste — gets clean structural Markdown
- [x] Falls back to `input.text` when no HTML is available
- [x] `bun run check` (tsc --noEmit) — passes
- [x] `bunx biome check .` — passes