### PR TITLE
Add Reflow extension

### DIFF
--- a/contrib/Reflow.popclipext/Config.json
+++ b/contrib/Reflow.popclipext/Config.json
@@ -1,0 +1,7 @@
+{
+  "identifier": "com.stympy.popclip.extension.clean-paste",
+  "name": "Reflow",
+  "icon": "symbol:wand.and.stars",
+  "description": "Clean up messy terminal paste by removing prompts, fixing line wrapping, and joining paragraphs.",
+  "javascript": "const text = popclip.input.text.replace(/^❯\\s*/gm, ''); const lines = text.split('\\n'); const paragraphs = []; let current = []; for (const line of lines) { if (line.trim() === '') { if (current.length) { paragraphs.push(current); current = []; } } else { current.push(line.trim()); } } if (current.length) paragraphs.push(current); popclip.pasteText(paragraphs.map(p => p.join(' ').replace(/\\s{2,}/g, ' ')).join('\\n\\n'));"
+}

--- a/contrib/Reflow.popclipext/Readme.md
+++ b/contrib/Reflow.popclipext/Readme.md
@@ -1,0 +1,27 @@
+# Reflow
+
+Clean up messy text pasted from terminal output (e.g. Claude Code). Removes
+the `❯` prompt character, joins soft-wrapped lines into proper paragraphs, and
+collapses excess whitespace.
+
+## About
+
+This is an extension for [PopClip](https://www.popclip.app/).
+
+### Author
+
+Benjamin Curtis
+
+### Credits
+
+Inspired by and derived from Simon Willison's [Cleanup Claude Code Paste](https://tools.simonwillison.net/cleanup-claude-code-paste) tool.
+
+### Requirements
+
+Requires PopClip 2021.11
+
+## Changelog
+
+### 6 Apr 2026
+
+* Initial release.


### PR DESCRIPTION
## Summary

- Adds a new **Reflow** extension to `contrib/` that cleans up text pasted from terminal output (e.g. Claude Code)
- Removes the `❯` prompt character, joins soft-wrapped lines into proper paragraphs, and collapses excess whitespace
- Uses inline JavaScript in Config.json — no external dependencies

## Credits

Inspired by Simon Willison's [Cleanup Claude Code Paste](https://tools.simonwillison.net/cleanup-claude-code-paste) tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)