### PR TITLE
Add LLM CLI extension

### DIFF
--- a/contrib/LLMCLI.popclipext/Config.json
+++ b/contrib/LLMCLI.popclipext/Config.json
@@ -1,0 +1,47 @@
+{
+  "identifier": "com.pestly.popclip.extension.llm-cli-rewrite",
+  "popclip version": 5155,
+  "name": "LLM CLI",
+  "icon": "symbol:brain",
+  "description": "Rewrite selected text through Codex, Claude, Gemini, or OpenCode CLI.",
+  "requirements": ["text"],
+  "after": "paste-result",
+  "restore pasteboard": false,
+  "interpreter": "/bin/zsh",
+  "shell script file": "rewrite.zsh",
+  "stdin": "text",
+  "options": [
+    {
+      "identifier": "provider",
+      "label": "Provider",
+      "type": "multiple",
+      "values": ["codex", "claude", "gemini", "opencode"],
+      "valueLabels": ["Codex CLI", "Claude CLI", "Gemini CLI", "OpenCode CLI"],
+      "defaultValue": "codex",
+      "description": "CLI provider to use. The provider must already be installed and logged in."
+    },
+    {
+      "identifier": "preset",
+      "label": "Preset",
+      "type": "multiple",
+      "values": ["duzelt", "chat", "mail", "musteri", "custom"],
+      "valueLabels": ["Düzelt", "Chat Kurumsal", "Mail Kurumsal", "Müşteri Tonu", "Custom"],
+      "defaultValue": "duzelt",
+      "description": "Rewrite style."
+    },
+    {
+      "identifier": "model",
+      "label": "Model",
+      "type": "string",
+      "defaultValue": "",
+      "description": "Optional model name. Leave blank to use the CLI default."
+    },
+    {
+      "identifier": "customprompt",
+      "label": "Custom Prompt",
+      "type": "string",
+      "defaultValue": "",
+      "description": "Used only when Preset is Custom."
+    }
+  ]
+}

--- a/contrib/LLMCLI.popclipext/Readme.md
+++ b/contrib/LLMCLI.popclipext/Readme.md
@@ -1,0 +1,52 @@
+# LLM CLI
+
+Author: Abdullah Peşteli
+
+Rewrite selected text using a logged-in command-line LLM client.
+
+This extension is for users who already use one of the supported CLI tools and
+want PopClip to send the selected text to that CLI without entering a separate
+API key in PopClip.
+
+Supported providers:
+
+- Codex CLI
+- Claude CLI
+- Gemini CLI
+- OpenCode CLI
+
+The provider must already be installed, available on `PATH`, and logged in.
+
+## Usage
+
+1. Select text.
+2. Click the LLM CLI action.
+3. The selected text is replaced with the rewritten text.
+
+The extension settings let you choose:
+
+- Provider
+- Preset
+- Optional model name
+- Custom prompt, when the Custom preset is selected
+
+## Presets
+
+- Düzelt: minimal Turkish spelling and punctuation correction.
+- Chat Kurumsal: clearer WhatsApp/Telegram work-message tone.
+- Mail Kurumsal: professional client-facing email tone.
+- Müşteri Tonu: warmer corporate client communication.
+- Custom: use your own instruction from the extension settings.
+
+## Notes
+
+This extension invokes third-party CLI tools. Selected text is sent to whichever
+provider/model you configure in that CLI. Review your provider's privacy and
+data-use settings before using the extension with sensitive text.
+
+The extension uses a shell script because PopClip's JavaScript environment
+cannot run external CLI commands directly.
+
+## Changelog
+
+- 2026-07-02: Initial version.

--- a/contrib/LLMCLI.popclipext/rewrite.zsh
+++ b/contrib/LLMCLI.popclipext/rewrite.zsh
@@ -1,0 +1,127 @@
+#!/bin/zsh
+set -euo pipefail
+
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+
+# PopClip's shell PATH can be thinner than an interactive terminal. Cover common
+# Homebrew, npm, and system locations without hard-coding a single machine.
+export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+provider="${POPCLIP_OPTION_PROVIDER:-codex}"
+preset="${POPCLIP_OPTION_PRESET:-duzelt}"
+model="${POPCLIP_OPTION_MODEL:-}"
+custom_prompt="${POPCLIP_OPTION_CUSTOMPROMPT:-}"
+input="$(cat)"
+
+if [[ -z "${input//[[:space:]]/}" ]]; then
+  exit 1
+fi
+
+case "$preset" in
+  duzelt)
+    instruction='You are a minimal Turkish text corrector. Do not answer questions; only return the corrected version of the user text. Preserve meaning, intent, negation, uncertainty, speaker perspective, names, links, model names, commands, and UI terms. Fix only spelling, punctuation, capitalization, question suffix spacing, obvious letter/suffix errors, and run-on sentence breaks. Do not make the text formal, corporate, literary, or artificial. Do not add explanations, headings, alternatives, comments, or new information.'
+    ;;
+  chat)
+    instruction='You rewrite Turkish WhatsApp/Telegram work-group messages into a natural but clearer business chat tone. Never answer the user text; only rewrite the selected message. Preserve the speaker perspective. This is not an email: do not add greeting, closing, signature, or heavy formal language unless already present. Do not summarize long text. Preserve action direction for verbs such as çıkar, çıksın, ekle, kalsın, değişmesin, silinsin. Preserve revision ranges and timecodes exactly.'
+    ;;
+  mail)
+    instruction='You rewrite Turkish email drafts into professional, clear, natural client-facing Turkish. Return only the rewritten email body. Preserve speaker perspective. If the draft is a note, keep it as a note; do not turn it into a representative answer. Do not add information, dates, budget, approvals, delivery promises, or links not present in the input. Preserve numeric ranges such as 1.23, 2.04-2.27, 00:15-00:22 exactly; do not reinterpret them as dates. Avoid heavy bureaucratic Turkish.'
+    ;;
+  musteri)
+    instruction='You rewrite Turkish text into a corporate client communication tone. Never answer questions or requests in the selected text; only rewrite it. Preserve speaker perspective. Use clear, polite, warm but not artificially formal Turkish. Preserve links, dates, times, timecodes, names, brands, and project names. If the source is uncertain, keep the uncertainty. Do not add new brief details, budget, dates, approvals, links, or commitments.'
+    ;;
+  custom)
+    instruction="$custom_prompt"
+    ;;
+  *)
+    echo "Unknown preset: $preset" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "${instruction//[[:space:]]/}" ]]; then
+  echo "Custom Prompt is empty." >&2
+  exit 2
+fi
+
+prompt="${instruction}
+
+Rules:
+- Return only the final rewritten text.
+- Do not output Markdown, code fences, headings, options, analysis, or thinking text.
+- Do not answer the text; rewrite it.
+- Preserve punctuation style inside numeric ranges and timecodes exactly, for example 2.04-2.27 or 00:15-00:22.
+
+Text:
+${input}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing CLI: $1. Install it and log in first." >&2
+    exit 2
+  fi
+}
+
+run_gemini() {
+  require_command gemini
+  if [[ -n "$model" ]]; then
+    gemini -m "$model" -p "$prompt" --output-format text 2>/dev/null
+  else
+    gemini -p "$prompt" --output-format text 2>/dev/null
+  fi
+}
+
+run_claude() {
+  require_command claude
+  if [[ -n "$model" ]]; then
+    claude -p --output-format text --no-session-persistence --model "$model" "$prompt" 2>/dev/null
+  else
+    claude -p --output-format text --no-session-persistence "$prompt" 2>/dev/null
+  fi
+}
+
+run_codex() {
+  require_command codex
+  local out
+  out="$(mktemp "${TMPDIR:-/tmp}/popclip-codex.XXXXXX")"
+  if [[ -n "$model" ]]; then
+    printf "%s" "$prompt" | codex exec --model "$model" --sandbox read-only --skip-git-repo-check --ephemeral --output-last-message "$out" - >/dev/null 2>/dev/null
+  else
+    printf "%s" "$prompt" | codex exec --sandbox read-only --skip-git-repo-check --ephemeral --output-last-message "$out" - >/dev/null 2>/dev/null
+  fi
+  cat "$out"
+  rm -f "$out"
+}
+
+run_opencode() {
+  require_command opencode
+  if [[ -n "$model" ]]; then
+    opencode run --model "$model" -- "$prompt" 2>/dev/null
+  else
+    opencode run -- "$prompt" 2>/dev/null
+  fi
+}
+
+case "$provider" in
+  codex) raw="$(run_codex)" ;;
+  claude) raw="$(run_claude)" ;;
+  gemini) raw="$(run_gemini)" ;;
+  opencode) raw="$(run_opencode)" ;;
+  *)
+    echo "Unknown provider: $provider" >&2
+    exit 2
+    ;;
+esac
+
+cleaned="$(printf "%s" "$raw" \
+  | perl -CS -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g' \
+  | sed -e '/^\[opencode-mobile\]/d' -e '/^> build · /d' \
+  | sed -e 's/^[[:space:]]*```[[:alnum:]_-]*[[:space:]]*$//' -e 's/^[[:space:]]*```[[:space:]]*$//' \
+  | sed -e '1{/^[[:space:]]*$/d;}' -e '${/^[[:space:]]*$/d;}')"
+
+if [[ -z "${cleaned//[[:space:]]/}" ]]; then
+  exit 1
+fi
+
+printf "%s" "$cleaned"


### PR DESCRIPTION
Adds a contrib extension named LLM CLI.\n\nThe extension rewrites selected text by invoking an already installed and logged-in command-line LLM client. It currently supports Codex CLI, Claude CLI, Gemini CLI, and OpenCode CLI, with a few preset rewrite modes and a custom prompt option.\n\nNotes:\n- Submitted under contrib because it depends on external CLI tools and user login state.\n- No API keys are stored in PopClip.\n- The script only invokes the selected local CLI and returns stdout as the replacement text.\n- Includes a Readme with provider setup, privacy notes, and changelog.\n\nI understand this may not fit the main Extension Directory criteria because it requires third-party CLI tools, but it may still be useful as a contrib extension for users who already use these CLIs.