### PR TITLE
Add cmux support to Terminal plugin

### DIFF
--- a/source/RunCommand.popclipext/Config.json
+++ b/source/RunCommand.popclipext/Config.json
@@ -1,8 +1,8 @@
 {
   "name": "Terminal",
   "identifier": "com.pilotmoon.popclip.extension.rtc",
-  "description": "Run the selected text as a command in the active terminal window with optional prepend/append text. Supports Terminal, iTerm2, Warp, Ghostty, and kitty.",
-  "keywords": "terminal iterm2 warp ghostty kitty run command",
+  "description": "Run the selected text as a command in the active terminal window with optional prepend/append text. Supports Terminal, iTerm2, Warp, Ghostty, kitty, and cmux.",
+  "keywords": "terminal iterm2 warp ghostty kitty cmux run command",
   "popclip version": 4151,
   "icon": "RTC.png",
   "actions": [
@@ -49,14 +49,24 @@
         "bundleIdentifiers": ["net.kovidgoyal.kitty"],
         "checkInstalled": false
       }
+    },
+    {
+      "requirements": ["text", "option-term=cmux"],
+      "applescript file": "cmux.applescript",
+      "app": {
+        "name": "cmux",
+        "link": "https://cmux.io/",
+        "bundleIdentifiers": ["com.cmuxterm.app"],
+        "checkInstalled": false
+      }
     }
   ],
   "options": [
     {
       "label": "Terminal Emulator",
       "type": "multiple",
-      "values": ["Terminal", "iTerm2 v2.9+", "Warp", "Ghostty", "kitty"],
-      "valueLabels": ["Terminal", "iTerm2", "Warp", "Ghostty", "kitty"],
+      "values": ["Terminal", "iTerm2 v2.9+", "Warp", "Ghostty", "kitty", "cmux"],
+      "valueLabels": ["Terminal", "iTerm2", "Warp", "Ghostty", "kitty", "cmux"],
       "identifier": "term"
     },
     {

--- a/source/RunCommand.popclipext/Config.json
+++ b/source/RunCommand.popclipext/Config.json
@@ -55,7 +55,7 @@
       "applescript file": "cmux.applescript",
       "app": {
         "name": "cmux",
-        "link": "https://cmux.io/",
+        "link": "https://cmux.com/",
         "bundleIdentifiers": ["com.cmuxterm.app"],
         "checkInstalled": false
       }

--- a/source/RunCommand.popclipext/README.md
+++ b/source/RunCommand.popclipext/README.md
@@ -3,8 +3,8 @@
 Runs the selected text as a command in the current terminal window.
 
 One can choose either default Terminal, [iTerm2](https://iterm2.com/),
-[Warp](https://www.warp.dev/), [Ghostty](https://ghostty.org/), or 
-[kitty](https://sw.kovidgoyal.net/kitty/).
+[Warp](https://www.warp.dev/), [Ghostty](https://ghostty.org/),
+[kitty](https://sw.kovidgoyal.net/kitty/), or [cmux](https://cmux.io/).
 
 ## Features
 
@@ -31,7 +31,8 @@ One can choose either default Terminal, [iTerm2](https://iterm2.com/),
 
 In the extension settings, you can configure:
 
-- Terminal Emulator: Choose between Terminal, iTerm2, Warp, Ghostty, or kitty.
+- Terminal Emulator: Choose between Terminal, iTerm2, Warp, Ghostty, kitty, or
+  cmux.
 - Prepend Command: Text to insert before the selected text (optional)
 - Append Command: Text to insert after the selected text (optional)
 - Use New Tab: Opens command in a new tab instead of the current tab
@@ -50,6 +51,7 @@ Prepend/append functionality added by Shayon Pal. Ghosstty support added by
 
 ## Changelog
 
+- 11 Jul 2026: Add cmux support.
 - 28 Nov 2025: Add kitty support.
 - 20 Oct 2025: Add Ghostty support.
 - 29 May 2025: Added 'Use New Tab' option to run commands in a new terminal tab;

--- a/source/RunCommand.popclipext/README.md
+++ b/source/RunCommand.popclipext/README.md
@@ -4,7 +4,7 @@ Runs the selected text as a command in the current terminal window.
 
 One can choose either default Terminal, [iTerm2](https://iterm2.com/),
 [Warp](https://www.warp.dev/), [Ghostty](https://ghostty.org/),
-[kitty](https://sw.kovidgoyal.net/kitty/), or [cmux](https://cmux.io/).
+[kitty](https://sw.kovidgoyal.net/kitty/), or [cmux](https://cmux.com/).
 
 ## Features
 

--- a/source/RunCommand.popclipext/cmux.applescript
+++ b/source/RunCommand.popclipext/cmux.applescript
@@ -1,0 +1,127 @@
+-- AppleScript for cmux integration with PopClip
+-- This script takes the selected text from PopClip and sends it to cmux
+-- It uses the application ID to ensure proper identification of cmux
+
+-- Configuration Properties
+-- Set this property to true to always open in a new window
+property open_in_new_window : false
+
+-- Set this property to false to reuse the current tab
+property open_in_new_tab : false
+
+-- ========== Handler Definitions ==========
+
+-- Creates a new cmux window using keyboard shortcut Cmd+N
+on new_window()
+	tell application "System Events"
+		tell process "cmux"
+			keystroke "n" using command down
+		end tell
+	end tell
+end new_window
+
+-- Creates a new tab in the current cmux window using keyboard shortcut Cmd+T
+on new_tab()
+	tell application "System Events"
+		tell process "cmux"
+			keystroke "t" using command down
+		end tell
+	end tell
+end new_tab
+
+-- Activates cmux and brings it to the foreground
+-- This ensures commands are sent to the correct application
+on call_forward()
+	tell application id "com.cmuxterm.app"
+		-- Launch cmux if not running or bring to front if it is
+		activate
+
+		-- Ensure cmux is the frontmost application using System Events
+		tell application "System Events"
+			tell process "cmux"
+				if (count of windows) is 0 then
+					-- If cmux has no window then tell it to reopen
+					tell application id "com.cmuxterm.app" to reopen
+				end if
+
+				set frontmost to true
+			end tell
+		end tell
+	end tell
+end call_forward
+
+-- Sends text to cmux and executes it by pressing Return (key code 36)
+-- The delays help ensure the terminal is ready for input
+on send_text(custom_text)
+	tell application "System Events"
+		tell process "cmux"
+			-- Small delay to ensure cmux is ready
+			delay 0.1
+
+			-- Get the previous value of the clipboard
+			set previousClipboard to the clipboard
+			-- Set the custom text to the clipboard
+			set the clipboard to custom_text
+
+			delay 0.05
+
+			-- Paste the text into cmux
+			keystroke "v" using {command down}
+
+			-- Small delay before pressing Return
+			delay 0.05
+
+			-- Press Return to execute the command
+			-- Key code 36 is the Return key
+			key code 36
+
+			-- Set the clipboard to previous value
+			if previousClipboard is not missing value then
+				set the clipboard to previousClipboard
+			end if
+		end tell
+	end tell
+end send_text
+
+-- ========== Main Program ==========
+
+-- First activate cmux and bring it to the foreground
+call_forward()
+
+-- Get the "Use New Tab" option from PopClip
+set use_new_tab to "{popclip option newtab}" is "1"
+
+-- Determine where to send the command based on configuration
+if open_in_new_window then
+	-- Create a new window if configured to do so
+	new_window()
+else if use_new_tab then
+	-- Create a new tab if requested via PopClip option
+	new_tab()
+else
+	-- Otherwise reuse the current tab (no action needed)
+end if
+
+-- Ensure cmux is still in focus after potential window/tab changes
+call_forward()
+
+-- Retrieve optional prefix and suffix text from PopClip extension settings
+-- These allow customizing the command with text before or after the selection
+set prepend_text to "{popclip option prepend}"
+set append_text to "{popclip option append}"
+
+-- Handle different combinations of prepend/append text
+-- and construct the final command to execute
+if prepend_text is not "" and append_text is not "" then
+	-- Both prepend and append text are provided
+	send_text(prepend_text & " {popclip text} " & append_text)
+else if prepend_text is not "" then
+	-- Only prepend text is provided
+	send_text(prepend_text & " {popclip text}")
+else if append_text is not "" then
+	-- Only append text is provided
+	send_text("{popclip text} " & append_text)
+else
+	-- No prepend or append text, just run the selected text as a command
+	send_text("{popclip text}")
+end if


### PR DESCRIPTION
Add [cmux](https://cmux.com) as a terminal emulator option in the RunCommand (Terminal) extension. Uses the clipboard-paste + keystroke approach (like Ghostty) since cmux is a native app without deep AppleScript support