### PR TITLE
Add ClariRec extension

### DIFF
--- a/contrib/ClariRec.popclipext/Config.yaml
+++ b/contrib/ClariRec.popclipext/Config.yaml
@@ -1,0 +1,14 @@
+# popclip extension for ClariRec
+# https://clarirec.com
+name: ClariRec
+identifier: com.guodongzhu.clarirec.popclip
+description: Translate the selected text with ClariRec.
+icon: symbol:translate
+popclip version: 5155
+app:
+  name: ClariRec
+  link: https://clarirec.com
+  check installed: true
+  bundle identifiers:
+    - com.guodongzhu.ClariRec
+service name: Translate with ClariRec

--- a/contrib/ClariRec.popclipext/Readme.md
+++ b/contrib/ClariRec.popclipext/Readme.md
@@ -1,0 +1,35 @@
+# ClariRec
+
+Translate the selected text with [ClariRec](https://clarirec.com), an OCR and translation utility for macOS.
+
+## Usage
+
+Select text in any app and click the ClariRec button in the PopClip bar. The translation appears in ClariRec's compact Mini HUD near the pointer, without stealing focus from the app you are working in.
+
+The translation uses whichever engine you have configured in ClariRec:
+
+- macOS system translation (macOS 15 Sequoia or later, works out of the box)
+- Apple Intelligence (Macs that support it, running macOS 26 Tahoe or later)
+- A local on-device model (optional download, fully offline)
+- Your own API key (BYOK): DeepL, OpenAI, Anthropic, DeepSeek, GLM, SiliconFlow, Grok, OpenRouter, and more
+
+Change the target language or engine in ClariRec's settings, or directly from the HUD.
+
+## Requirements
+
+- [ClariRec](https://apps.apple.com/us/app/clarirec/id6757385283?mt=12) (free on the Mac App Store)
+- The extension invokes ClariRec's "Translate with ClariRec" macOS Service, so ClariRec must have been launched at least once for the service to register.
+
+## Notes
+
+This extension uses the standard macOS Services mechanism — no Accessibility permission, no scripts.
+
+## Credits
+
+Extension by Harry Chu and the ClariRec team.
+
+## Changelog
+
+### 1.0 (2026-07-16)
+
+- Initial release: translate selected text via ClariRec's macOS Service.


### PR DESCRIPTION
## New extension: ClariRec

Companion extension for [ClariRec](https://clarirec.com), an OCR and translation utility for macOS ([Mac App Store](https://apps.apple.com/us/app/clarirec/id6757385283?mt=12), free).

### What it does

Sends the selected text to ClariRec's `Translate with ClariRec` macOS Service. The translation appears in ClariRec's compact non-activating Mini HUD near the pointer, without stealing focus from the app the user is working in.

### Implementation notes

- Pure `service name` action — no scripts, no compiled binaries, no Accessibility permission needed.
- `app` dictionary included with `check installed` and bundle identifier, linking to the official site when ClariRec is not installed.
- Translation engine is whatever the user configured in ClariRec: macOS system translation (works out of the box on macOS 15+), Apple Intelligence, a local on-device model, or their own API key (DeepL, OpenAI, Anthropic, DeepSeek, and others).
- Compared with the existing translation extensions, ClariRec's focus is the low-intrusion HUD presentation and local/BYOK engines; the extension itself does one thing only: translate the selected text.

### Testing

Verified on macOS 15 with PopClip build 5155 against ClariRec 2.2.2 (current Mac App Store release): selecting text and clicking the ClariRec button pops the translation HUD as described.

